### PR TITLE
Remove demo section from README and relocate to a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Demo
+
+[visual-search-demo.webm](https://github.com/user-attachments/assets/ec0d0315-f1b7-46dc-875b-a8293bf03280)
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # Demo
 
-[visual-search-demo.webm](https://github.com/user-attachments/assets/ec0d0315-f1b7-46dc-875b-a8293bf03280)
-
+[visual-search-demo.webm](https://github.com/user-attachments/assets/ef1795f7-1264-489c-be94-25bf2e1b7674)

--- a/server/README.md
+++ b/server/README.md
@@ -2,11 +2,6 @@
 
 This Express.js application provides a backend API for an e-commerce store with advanced search capabilities, including text-based semantic search and image-based visual search powered by vector embeddings.
 
-## Demo
-
-[visual-search-demo.webm](https://github.com/user-attachments/assets/ec0d0315-f1b7-46dc-875b-a8293bf03280)
-
-
 ## Features
 
 - **Product Management**: CRUD operations for product catalog


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a demo section with a link to a visual search demo video.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R4): Added a demo section with a link to a visual search demo video.
* [`server/README.md`](diffhunk://#diff-93e4a5263a598aad80002d4a45f54108d127c70824825011385e95987b233f8dL5-L9): Removed the demo section and the link to the visual search demo video.